### PR TITLE
WIP: Automation to identify changes in inactive areas

### DIFF
--- a/.github/scripts/triage/check-changes-ownership.js
+++ b/.github/scripts/triage/check-changes-ownership.js
@@ -1,28 +1,37 @@
-const fs = require('fs');
-const YAML = require('yaml');
 const utils = require('./utils')
 
-function changesInInactiveAreas(core, changedAreas) {
-    const areas = utils.getAllAreas(core);
-
-    let changesWithoutAreas = [];
+async function changesInInactiveAreas(core, context, github, areas, changedAreas) {
+    let changesWithoutOwners = [];
     const areaOwnersMap = utils.getActiveAreasWithCodeOwners(areas);
 
     changedAreas.forEach(ca => {
         if (!areaOwnersMap.has(ca)) {
-            changesWithoutAreas.push(ca);
+            changesWithoutOwners.push(ca);
         }
     });
 
-    if (changesWithoutAreas.length > 0) {
-        core.info("PR contains changes to areas that are not active");
+    if (changesWithoutOwners.length > 0) {
+        core.setFailed(`The pull request PR contains changes to areas that are not active:\n${changesWithoutOwners.join('\n')}`)
+        await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['triage:rejected:declined']
+            })
+        await github.rest.pulls.createReviewComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number,
+            commit_id: context.sha,
+            body: 'PR contains changes to areas that are not active'
+        });
     }
 
-    return changesWithoutAreas;
+    return changesWithoutOwners;
 }
 
-const findChangesInInactiveAreas = (core, changedAreas) => {
-    return changesInInactiveAreas(core, JSON.parse(changedAreas));
+const findChangesInInactiveAreas = async (core, context, github, areas, changedAreas) => {
+    await changesInInactiveAreas(core, context, github, areas, JSON.parse(changedAreas));
 }
 
 module.exports = findChangesInInactiveAreas;

--- a/.github/scripts/triage/check-changes-ownership.js
+++ b/.github/scripts/triage/check-changes-ownership.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const YAML = require('yaml');
+const utils = require('./utils')
+
+function changesInInactiveAreas(core, changedAreas) {
+    const areas = utils.getAllAreas(core);
+
+    let changesWithoutAreas = [];
+    const areaOwnersMap = utils.getActiveAreasWithCodeOwners(areas);
+
+    changedAreas.forEach(ca => {
+        if (!areaOwnersMap.has(ca)) {
+            changesWithoutAreas.push(ca);
+        }
+    });
+
+    if (changesWithoutAreas.length > 0) {
+        core.info("PR contains changes to areas that are not active");
+    }
+
+    return changesWithoutAreas;
+}
+
+const findChangesInInactiveAreas = (core, changedAreas) => {
+    return changesInInactiveAreas(core, JSON.parse(changedAreas));
+}
+
+module.exports = findChangesInInactiveAreas;

--- a/.github/scripts/triage/utils.js
+++ b/.github/scripts/triage/utils.js
@@ -1,16 +1,3 @@
-const fs = require('fs');
-const YAML = require('yaml');
-
-function getAllAreas(core) {
-    try {
-        const fileContent = fs.readFileSync('./areas.yaml', 'utf8');
-        const data = YAML.parse(fileContent);
-        return data.areas;
-    } catch (error) {
-        core.setFailed(`Failed to parse areas.yaml: ${error.message}`);
-    }
-}
-
 function isAreaActive(area) {
     return area.status.includes('accepting_contributions') || area.status.includes('active');
 }
@@ -35,7 +22,6 @@ function getActiveAreasWithCodeOwners(areas) {
 }
 
 module.exports = {
-    getAllAreas: getAllAreas,
     isAreaActive: isAreaActive,
     getActiveAreasWithCodeOwners: getActiveAreasWithCodeOwners
 };

--- a/.github/scripts/triage/utils.js
+++ b/.github/scripts/triage/utils.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const YAML = require('yaml');
+
+function getAllAreas(core) {
+    try {
+        const fileContent = fs.readFileSync('./areas.yaml', 'utf8');
+        const data = YAML.parse(fileContent);
+        return data.areas;
+    } catch (error) {
+        core.setFailed(`Failed to parse areas.yaml: ${error.message}`);
+    }
+}
+
+function isAreaActive(area) {
+    return area.status.includes('accepting_contributions') || area.status.includes('active');
+}
+
+function getActiveAreasWithCodeOwners(areas) {
+    const areaOwnersMap = new Map();
+    areas.filter(a => isAreaActive(a)).forEach((area) => {
+        area.labels.forEach((l) => {
+            const labelWithoutPrefix = l.slice('area:'.length);
+            // use all areas as map key
+            if (!areaOwnersMap.has(labelWithoutPrefix)) {
+                areaOwnersMap.set(labelWithoutPrefix, new Set());
+            }
+            // add all owners - an area can be owned by multiple teams
+            // as well as a team own many areas.
+            area.owner.forEach((owner) => {
+                areaOwnersMap.get(labelWithoutPrefix).add(owner.github);
+            });
+        });
+    });
+    return areaOwnersMap;
+}
+
+module.exports = {
+    getAllAreas: getAllAreas,
+    isAreaActive: isAreaActive,
+    getActiveAreasWithCodeOwners: getActiveAreasWithCodeOwners
+};

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -133,3 +133,27 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: check if the areas table is out-of-date
       run: make areas-table-check
+
+  validate-area-ownership:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: ${{ github.repository_owner == 'open-telemetry' }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Get changed files
+        id: diff
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        with:
+          dir_names: true
+          files: model/**
+
+      - name: Validate if PR has active owners
+        if: steps.diff.outputs.any_changed == 'true'
+        uses: actions/github-script@v8
+        id: changes-active-codeowners
+        with:
+          script: |
+            const script = require('.github/scripts/check-changes-ownership.js')
+            return script({core}, '${{ steps.diff.outputs.all_changed_files }}');

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   markdownlint:
@@ -138,7 +139,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -146,8 +146,11 @@ jobs:
         id: diff
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
-          dir_names: true
+          dir_names: "true"
           files: model/**
+          json: "true"
+
+      - run: npm install yaml@2.8.1
 
       - name: Validate if PR has active owners
         if: steps.diff.outputs.any_changed == 'true'
@@ -155,5 +158,9 @@ jobs:
         id: changes-active-codeowners
         with:
           script: |
-            const script = require('.github/scripts/check-changes-ownership.js')
-            return script({core}, '${{ steps.diff.outputs.all_changed_files }}');
+            const fs = require('fs');
+            const YAML = require('yaml')
+            const fileContent = fs.readFileSync('./areas.yaml', 'utf8')
+            const data = YAML.parse(fileContent)
+            const script = require('.github/scripts/triage/check-changes-ownership.js')
+            await script(core, context, github, data.areas, '${{ steps.diff.outputs.all_changed_files }}')

--- a/model/http/common.yaml
+++ b/model/http/common.yaml
@@ -10,7 +10,7 @@ groups:
           conditionally_required: If and only if one was received/sent.
       - ref: error.type
         requirement_level:
-          conditionally_required: If request has ended with an error.
+          conditionally_required: If request has ended with an error xyz.
         examples: ['timeout', 'java.net.UnknownHostException', 'server_certificate_invalid', '500']
         note: |
           If the request fails with an error before response status code was sent or received,

--- a/model/messaging/spans.yaml
+++ b/model/messaging/spans.yaml
@@ -12,7 +12,7 @@ groups:
       - ref: messaging.operation.type
         requirement_level:
           conditionally_required: If applicable.
-        sampling_relevant: true
+        sampling_relevant: false
       - ref: messaging.destination.name
         requirement_level:
           conditionally_required: If span describes operation on a single message or if the value applies to all messages in the batch.


### PR DESCRIPTION
Fixes #

## Changes

Please provide a brief description of the changes here.

Note: if the PR is touching an area that is not listed in the [existing areas](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md), or the area does not have sufficient [domain experts coverage](https://github.com/open-telemetry/semantic-conventions/blob/main/.github/CODEOWNERS), the PR might be tagged as [experts needed](https://github.com/open-telemetry/semantic-conventions/labels/experts%20needed) and move slowly until experts are identified.

## Merge requirement checklist

* [ ] [CONTRIBUTING.md](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md) guidelines followed.
* [ ] Change log entry added, according to the guidelines in [When to add a changelog entry](https://github.com/open-telemetry/semantic-conventions/blob/main/CONTRIBUTING.md#when-to-add-a-changelog-entry).
  * If your PR does not need a change log, start the PR title with `[chore]`
* [ ] Links to the prototypes or existing instrumentations (when adding or changing conventions)
